### PR TITLE
Fix mapper crash on non-string input

### DIFF
--- a/src/lib/rules-engine.ts
+++ b/src/lib/rules-engine.ts
@@ -121,7 +121,7 @@ function clamp01(n?: number) {
 }
 
 function safeLower(s: any) {
-  return typeof s === 'string' ? s.toLowerCase() : s;
+  return s == null ? '' : String(s).toLowerCase();
 }
 
 // --------------------------

--- a/src/tests/engine.spec.ts
+++ b/src/tests/engine.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { RuleEngine, RuleSet } from '../lib/rules-engine';
+import { RuleEngine, RuleSet, simpleCountryMapper, simpleStateMapper } from '../lib/rules-engine';
 
 describe('RuleEngine validators', () => {
   const ruleSet: RuleSet = {
@@ -27,5 +27,15 @@ describe('RuleEngine validators', () => {
     const e = new RuleEngine(ruleSet);
     const res = await e.applyRow({ x: 'ok', cat: 'Alpha' } as any, '1');
     expect(res.normalizedRow.cat).toBe('A');
+  });
+});
+
+describe('simple mappers', () => {
+  it('simpleCountryMapper handles non-string input', () => {
+    expect(simpleCountryMapper(123 as any)).toBeNull();
+  });
+
+  it('simpleStateMapper handles non-string input', () => {
+    expect(simpleStateMapper(456 as any, 'US')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- prevent `safeLower` from returning non-string values
- test `simpleCountryMapper`/`simpleStateMapper` on non-string input

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a87c975510832ebf6b6d5da72be2df