### PR TITLE
docs: add upload bucket setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,14 @@
 
 This is a NextJS starter in Firebase Studio.
 
+## Setup
+
+Configure your Firebase Functions environment with the bucket where uploaded files should be stored:
+
+```bash
+firebase functions:config:set upload.bucket="<your-bucket>"
+```
+
+If this configuration is missing, uploads fail with the error `UPLOAD_BUCKET not set`.
+
 To get started, take a look at src/app/page.tsx.


### PR DESCRIPTION
## Summary
- document Firebase `upload.bucket` config step
- note that missing config causes `UPLOAD_BUCKET not set`

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68ac8a4a2eac832eb9f0f5a2f8fe3938