### PR TITLE
chore: add firebase and jaeger dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "deploy": "firebase deploy --only hosting,functions"
   },
   "dependencies": {
+    "@genkit-ai/firebase": "^1.14.1",
     "@genkit-ai/googleai": "^1.14.1",
     "@genkit-ai/next": "^1.14.1",
     "@google-cloud/bigquery": "^7.8.0",
@@ -23,6 +24,7 @@
     "@google-cloud/storage": "^7",
     "@google-cloud/vertexai": "^1.2.0",
     "@hookform/resolvers": "^4.1.3",
+    "@opentelemetry/exporter-jaeger": "^0.52.1",
     "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-alert-dialog": "^1.1.6",
     "@radix-ui/react-avatar": "^1.1.3",


### PR DESCRIPTION
## Summary
- add `@genkit-ai/firebase` and `@opentelemetry/exporter-jaeger` to dependencies

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden)*
- `firebase deploy --only functions,hosting` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac8a48ec7c832ebb63f78f8fafcf2b