### PR TITLE
feat: export rules builder

### DIFF
--- a/src/components/rule-builder.tsx
+++ b/src/components/rule-builder.tsx
@@ -94,7 +94,7 @@ const LIBRARY: Array<{key:string; title:string; desc:string; example?:string; ma
   { key: "cash_runway", title:"Cash‑Flow / Runway (enum)", desc:"Positive / Break‑even / Negative.", make: () => ({ ruleId:"cash_runway", type:"enum", appliesTo:"cash_runway", strategy:"auto_fix", enum:["Positive","Break-even","Negative"], synonyms:{positive:"Positive","break even":"Break-even",breakeven:"Break-even","break-even":"Break-even",negative:"Negative"} }) }
 ];
 
-function RulesBuilder() {
+export default function RulesBuilder() {
   const [ruleSetId, setRuleSetId] = useState("default");
   const [name, setName] = useState("default");
   const [version, setVersion] = useState(1);


### PR DESCRIPTION
## Summary
- export RulesBuilder as default from rule-builder component

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run typecheck` *(fails: Cannot find module '@/hooks/use-toast', ... and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_b_68ac8a492d88832eb8eb44b5c4d64fbc